### PR TITLE
Version bump reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ edition = "2018"
 
 
 [dependencies]
-serde_json = "1.0"
-reqwest = { version = "0.10", features = ["json"] }
-serde_derive = "1.0"
-serde = "1.0"
-jsonwebtoken = "7.1"
+serde_json = "1.0.62"
+reqwest = { version = "0.11.1", features = ["json"] }
+serde_derive = "1.0.123"
+serde = "1.0.123"
+jsonwebtoken = "7.2.0"


### PR DESCRIPTION
In order to use tokio 1.2.x, reqwest should be at least 0.11